### PR TITLE
ci: drop deprecated macos-13 runner, keep arm64 only

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -63,16 +63,8 @@ jobs:
 
   wheel-macos:
     needs: verify-on-main
-    strategy:
-      fail-fast: false
-      matrix:
-        include:
-          - os: macos-13
-            arch: x86_64
-          - os: macos-latest
-            arch: arm64
-    runs-on: ${{ matrix.os }}
-    name: Build wheel (macos-${{ matrix.arch }})
+    runs-on: macos-latest
+    name: Build wheel (macos-arm64)
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-python@v6
@@ -82,7 +74,7 @@ jobs:
       - run: pip install uv && uv build --wheel
       - uses: actions/upload-artifact@v4
         with:
-          name: wheel-macos-${{ matrix.arch }}
+          name: wheel-macos-arm64
           path: dist/*.whl
 
   publish:

--- a/README.md
+++ b/README.md
@@ -95,6 +95,12 @@ asyncio.run(readme())
 
 ## ChangeLog
 
+### v0.13.1
+
+#### CI
+
+- Drop deprecated `macos-13` (x86_64) runner from release workflow; `macos-latest` (arm64) only
+
 ### v0.13.0
 
 Requires Python 3.9+. Upgrade to FoundationDB 7.3 (API version 730).


### PR DESCRIPTION
macos-13 (x86_64) has been removed from GitHub-hosted runners. Simplify wheel-macos job to a single macos-latest (arm64) target.