### PR TITLE
ci: repair linux wheels with auditwheel to produce manylinux tags

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -56,6 +56,7 @@ jobs:
           python-version: "3.12"
       - run: sudo make debian
       - run: pip install uv && uv build --wheel
+      - run: pip install auditwheel && auditwheel repair dist/*.whl --plat manylinux_2_17_$(uname -m) --exclude libfdb_c.so -w dist/ && rm dist/*linux_$(uname -m).whl
       - uses: actions/upload-artifact@v4
         with:
           name: wheel-linux-${{ matrix.arch }}


### PR DESCRIPTION
PyPI rejects plain linux_* platform tags; run auditwheel repair after build to retag as manylinux_2_17_<arch>, excluding libfdb_c.so so it remains a system dependency rather than being bundled.